### PR TITLE
Fix creation subscription with not accepted mandate

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,9 @@
         </whitelist>
     </filter>
     <testsuites>
+        <testsuite name="features">
+            <directory>./tests/Features</directory>
+        </testsuite>
         <testsuite name="unit">
             <directory>./tests/Unit</directory>
         </testsuite>

--- a/src/Http/Endpoint/MapperInterface.php
+++ b/src/Http/Endpoint/MapperInterface.php
@@ -23,7 +23,7 @@ interface MapperInterface
     public const GET_SUBSCRIPTION_TRANSACTIONS = 'get_subscription_transactions';
 
     public const GET_TRANSACTION = 'get_transaction';
-    public const POST_TRANSACTION = 'get_transaction';
+    public const POST_TRANSACTION = 'post_transaction';
     public const DELETE_TRANSACTION = 'delete_transactions';
 
     /**

--- a/src/Resource/Factory/SubscriptionFactory.php
+++ b/src/Resource/Factory/SubscriptionFactory.php
@@ -56,7 +56,7 @@ final class SubscriptionFactory extends AbstractFactory implements SubscriptionF
         return new Mandate(
             $data['mandate_code'],
             $this->extractBoolean('mandate_accepted', $data),
-            new DateTimeImmutable($data['mandate_accepted_date'])
+            $this->extractDateTimeImmutableOrNull('mandate_accepted_date', $data)
         );
     }
 

--- a/src/Resource/Factory/Transaction/EventFactory.php
+++ b/src/Resource/Factory/Transaction/EventFactory.php
@@ -10,5 +10,6 @@ final class EventFactory implements EventFactoryInterface
 {
     public function fromArray(array $data): array
     {
+        return [];
     }
 }

--- a/src/eCurringClient.php
+++ b/src/eCurringClient.php
@@ -191,10 +191,15 @@ final class eCurringClient implements eCurringClientInterface
         );
     }
 
+    /**
+     * @param UuidInterface $id
+     * @return Transaction
+     * @throws Http\Exception\ApiCallException
+     */
     public function getTransaction(UuidInterface $id): Transaction
     {
         $json = $this->httpClient->getJson(
-            $this->httpClient->getEndpoint(MapperInterface::GET_SUBSCRIPTION_PLAN, [$id])
+            $this->httpClient->getEndpoint(MapperInterface::GET_TRANSACTION, [$id])
         );
 
         return $this->transactionFactory->fromData($this->decodeJsonToArray($json)['data']);

--- a/tests/Features/GetTransactionTest.php
+++ b/tests/Features/GetTransactionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+
+namespace LauLamanApps\eCurring\Tests\Features;
+
+use LauLamanApps\eCurring\Http\Endpoint\MapperInterface;
+use LauLamanApps\eCurring\Http\Endpoint\Production;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+class GetTransactionTest extends TestCase
+{
+    public function testGetTransaction()
+    {
+        $production = new Production();
+        $id = Uuid::uuid4()->toString();
+
+        $url = $production->map(MapperInterface::GET_TRANSACTION, [$id]);
+
+        $this->assertEquals(Production::BASE_URL . '/transactions/' . $id, $url);
+    }
+}

--- a/tests/Unit/Client/Factory/SubscriptionFactoryTest.php
+++ b/tests/Unit/Client/Factory/SubscriptionFactoryTest.php
@@ -46,7 +46,7 @@ final class SubscriptionFactoryTest extends TestCase
         self::assertEquals($data['data']['id'], $subscriptionPlan->getId());
         self::assertSame($data['data']['attributes']['mandate_code'], $subscriptionPlan->getMandate()->getCode());
         self::assertSame($data['data']['attributes']['mandate_accepted'], $subscriptionPlan->getMandate()->isAccepted());
-        self::assertSame($data['data']['attributes']['mandate_accepted_date'], $subscriptionPlan->getMandate()->getAcceptedDate()->format(DateTime::ATOM));
+        self::assertDateTimeOrNull($data['data']['attributes']['mandate_accepted_date'], $subscriptionPlan->getMandate()->getAcceptedDate());
         self::assertSame($data['data']['attributes']['start_date'], $subscriptionPlan->getStartDate()->format(DateTime::ATOM));
         self::assertSame($data['data']['attributes']['status'], $subscriptionPlan->getStatus()->getValue());
         self::assertSame($data['data']['attributes']['confirmation_page'], $subscriptionPlan->getConfirmationPage());
@@ -75,7 +75,8 @@ final class SubscriptionFactoryTest extends TestCase
     public function getTransactionData(): array
     {
         return [
-            'subscription' => [$this->getDataFromFile('subscription.json')],
+            [$this->getDataFromFile('subscription.json')],
+            [$this->getDataFromFile('subscription_mandate_is_not_accepted.json')],
         ];
     }
 }

--- a/tests/files/UnitTests/Client/Factory/SubscriptionFactoryTest/subscription_mandate_is_not_accepted.json
+++ b/tests/files/UnitTests/Client/Factory/SubscriptionFactoryTest/subscription_mandate_is_not_accepted.json
@@ -1,0 +1,53 @@
+{
+  "links": {
+    "self": "https://api.ecurring.com/subscriptions/1"
+  },
+  "data": {
+    "type": "subscription",
+    "id": "1",
+    "links": {
+      "self": "https://api.ecurring.com/subscriptions/1"
+    },
+    "attributes": {
+      "mandate_code": "ECUR-1",
+      "mandate_accepted": false,
+      "mandate_accepted_date": null,
+      "start_date": "2017-11-21T22:11:57+01:00",
+      "status": "active",
+      "cancel_date": null,
+      "resume_date": null,
+      "confirmation_page": "https://app.ecurring.com/mandate/accept/1/ECUR-1",
+      "confirmation_sent": false,
+      "subscription_webhook_url": null,
+      "transaction_webhook_url": null,
+      "success_redirect_url": null,
+      "created_at": "2017-02-01T11:21:09+01:00",
+      "updated_at": "2017-02-11T00:00:00+01:00"
+    },
+    "relationships": {
+      "subscription-plan": {
+        "data": {
+          "type": "subscription-plan",
+          "id": "1"
+        }
+      },
+      "customer": {
+        "data": {
+          "type": "customer",
+          "id": "1"
+        }
+      },
+      "transactions": {
+        "links": {
+          "related": "https://api.ecurring.com/subscriptions/1/transactions"
+        },
+        "data": [
+          {
+            "type": "transaction",
+            "id": "02f3c67b-1e1a-4692-8826-14f17f9b2c61"
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bug occurs when we try to initiate Subscription from api data without accepted mandate. 

"mandate_accepted": false,
"mandate_accepted_date": null,

